### PR TITLE
update token datatype for increased length

### DIFF
--- a/sqlbee.sql
+++ b/sqlbee.sql
@@ -128,8 +128,8 @@ create table `runtime_report_sensor` (
 
 create table `token` (
   `token_id` int(10) unsigned not null auto_increment,
-  `access_token` char(32) not null,
-  `refresh_token` char(32) not null,
+  `access_token` text not null,
+  `refresh_token` text not null,
   `timestamp` timestamp not null default current_timestamp,
   `deleted` tinyint(4) not null default '0',
   primary key (`token_id`)


### PR DESCRIPTION
Changed 'access_token' and 'refresh_token' fields in the 'token' table to be text instead of char.  New ecobee API has increased the length of the access tokens and refresh tokens.  They are now up to 7KB in length.  

Existing database can be fixed with the following commands in mysql:
ALTER TABLE token MODIFY COLUMN access_token text not null;
ALTER TABLE token MODIFY COLUMN refresh_token text not null;

API info - https://www.ecobee.com/home/developer/api/documentation/v1/auth/developer-migration-summary.shtml